### PR TITLE
Modify regex to allow negative numbers

### DIFF
--- a/Resources/converter.swift
+++ b/Resources/converter.swift
@@ -380,7 +380,7 @@ let rawInput = CommandLine.arguments[1].trimmingCharacters(in: .whitespacesAndNe
 
 // Parse number value
 guard
-  let rawNumber = rawInput.firstMatch(of: #/^(\d+(\.\d+)?)\D*/#)?.1,
+  let rawNumber = rawInput.firstMatch(of: #/^(-?\d+(\.\d+)?)\D*/#)?.1,
   let startNumber = Double(rawNumber)
 else {
   showItems([


### PR DESCRIPTION
The workflow doesn't currently allow converting negative numbers. I've added an optional hyphen to the regex to fix that.